### PR TITLE
[TASK] Add linting and use shivammathur/setup-php@v2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,12 +17,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: nanasess/setup-php@master
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          tools: composer:v2
 
       - name: Validate composer.json and composer.lock
         run: composer validate
+
+      - name: Lint PHP
+        uses: overtrue/phplint@7.4
+        with:
+          path: .
+          options: --exclude=vendor
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest


### PR DESCRIPTION
This PR adds PHP linting by using the `overtrue/phplint` action. For an
overall improved build performance, `shivammathur/setup-php` is used
in favor of `nanasess/setup-php`.