### PR TITLE
[FEATURE] Forward sanitization initiator to logging

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -27,8 +27,14 @@ class Context
      */
     public $parser;
 
-    public function __construct(HTML5 $parser)
+    /**
+     * @var InitiatorInterface
+     */
+    public $initiator;
+
+    public function __construct(HTML5 $parser, InitiatorInterface $initiator = null)
     {
         $this->parser = $parser;
+        $this->initiator = $initiator;
     }
 }

--- a/src/InitiatorInterface.php
+++ b/src/InitiatorInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under the terms
+ * of the MIT License (MIT). For the full copyright and license information,
+ * please read the LICENSE file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\HtmlSanitizer;
+
+/**
+ * Contractor for initiators, used to keep track of of origins
+ * of sanitization invocations. Data is forwared to logger (as string).
+ */
+interface InitiatorInterface
+{
+    public function __toString(): string;
+}

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -62,10 +62,10 @@ class Sanitizer
         $this->parser = $this->createParser();
     }
 
-    public function sanitize(string $html): string
+    public function sanitize(string $html, InitiatorInterface $initiator = null): string
     {
         $this->root = $this->parse($html);
-        $this->context = new Context($this->parser);
+        $this->context = new Context($this->parser, $initiator);
         $this->beforeTraverse();
         $this->traverseNodeList($this->root->childNodes);
         $this->afterTraverse();

--- a/src/Visitor/CommonVisitor.php
+++ b/src/Visitor/CommonVisitor.php
@@ -62,13 +62,13 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
         if ($tag === null) {
             // pass custom elements, in case it has been declared
             if ($this->behavior->shallAllowCustomElements() && $this->isCustomElement($node)) {
-                $this->logger->debug('Allowed custom element {nodeName}', [
+                $this->log('Allowed custom element {nodeName}', [
                     'behavior' => $this->behavior->getName(),
                     'nodeName' => $node->nodeName,
                 ]);
                 return $node;
             }
-            $this->logger->debug('Found unexpected tag {nodeName}', [
+            $this->log('Found unexpected tag {nodeName}', [
                 'behavior' => $this->behavior->getName(),
                 'nodeName' => $node->nodeName,
             ]);
@@ -135,7 +135,7 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
             && $node->childNodes->length > 0
             && $this->behavior->shallRemoveUnexpectedChildren()
         ) {
-            $this->logger->debug('Found unexpected children for {nodeName}', [
+            $this->log('Found unexpected children for {nodeName}', [
                 'behavior' => $this->behavior->getName(),
                 'nodeName' => $node->nodeName,
             ]);
@@ -161,7 +161,7 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
         $name = strtolower($attribute->name);
         $attr = $tag->getAttr($name);
         if ($attr === null || !$attr->matchesValue($attribute->value)) {
-            $this->logger->debug('Found invalid attribute {nodeName}.{attrName}', [
+            $this->log('Found invalid attribute {nodeName}.{attrName}', [
                 'behavior' => $this->behavior->getName(),
                 'nodeName' => $node->nodeName,
                 'attrName' => $attribute->nodeName,
@@ -211,5 +211,14 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
     {
         return $node instanceof DOMElement
             && preg_match('#^[a-z][a-z0-9]*-.+#', $node->nodeName) > 0;
+    }
+
+    protected function log(string $message, array $context = [], $level = null): void
+    {
+        // @todo consider given minimun log-level
+        if (!isset($context['initiator'])) {
+            $context['initiator'] = (string)$this->context->initiator;
+        }
+        $this->logger->debug($message, $context);
     }
 }


### PR DESCRIPTION
In order to detect potential flaws, a new `InitiatorInterface` is
introduced that contains individual stack-trace information and
needs to be implemented by corresponding consumers (e.g. TYPO3 CMS).
This allows to debug invocations and their context better.

Fixes: #27