### PR TITLE
[TASK] Replace overlint with native linting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         php: ['7.2', '7.4', '8.0']
 
@@ -27,10 +28,8 @@ jobs:
         run: composer validate
 
       - name: Lint PHP
-        uses: overtrue/phplint@7.4
-        with:
-          path: .
-          options: --exclude=vendor
+        run: |
+          find src/ tests/ -name '*.php' -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest


### PR DESCRIPTION
Although overlint can spawn multiple processes and may be faster,
version-specific code may slip through and remain uncovered, causing
issues in older PHP versions.

For this reason, overlint is replaced with native PHP linting. The
performance penalty can be ignored safely.