### PR TITLE
[TASK] Allow using microdata meta data

### DIFF
--- a/src/Builder/CommonBuilder.php
+++ b/src/Builder/CommonBuilder.php
@@ -134,6 +134,11 @@ class CommonBuilder implements BuilderInterface
         $tags['br'] = (new Behavior\Tag('br'))->addAttrs($this->globalAttrs);
         $tags['hr'] = (new Behavior\Tag('hr'))->addAttrs($this->globalAttrs);
         $tags['label']->addAttrs($this->createAttrs('for'));
+        // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta
+        $tags['meta'] = (new Behavior\Tag('meta', Behavior\Tag::PURGE_WITHOUT_ATTRS))->addAttrs(array_merge(
+            $this->globalAttrs,
+            [(new Behavior\Attr('content'))->addValues(new Behavior\RegExpAttrValue('#^[\w]*$#'))]
+        ));
 
         return $tags;
     }

--- a/tests/CommonBuilderTest.php
+++ b/tests/CommonBuilderTest.php
@@ -180,6 +180,20 @@ class CommonBuilderTest extends TestCase
                     '(the &lt;script&gt;alert(1)&lt;/script&gt; tag shall be encoded to HTML entities)'.
                 '</div>',
             ],
+            '#901' => [
+                '<div itemprop="tel" itemscope>' .
+                '<span itemprop="value">+1-234-56789</span>' .
+                '<meta itemprop="type" content="voice">' .
+                '</div>',
+                '<div itemprop="tel" itemscope>' .
+                '<span itemprop="value">+1-234-56789</span>' .
+                '<meta itemprop="type" content="voice">' .
+                '</div>'
+            ],
+            '#902' => [
+                '<div><meta http-equiv="refresh" content="1;https://evil.typo3.org/" name="referrer" charset="utf-8"></div>',
+                '<div></div>'
+            ],
         ];
     }
 


### PR DESCRIPTION
Allows using `<meta itemprop content>`, but denies other
usages like page refresh via `http-equiv`.

Related: #18