### PR TITLE
[TASK] Add support for data URIs

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,7 @@
     bootstrap="vendor/autoload.php"
     backupGlobals="true"
     colors="true"
-    processIsolation="true"
+    processIsolation="false"
     verbose="true">
     <testsuites>
         <testsuite name="tests">

--- a/src/Behavior/Attr.php
+++ b/src/Behavior/Attr.php
@@ -55,10 +55,33 @@ class Attr
         $this->flags = $flags;
     }
 
+    /**
+     * Adds value items directly to the current `Attr` instance.
+     *
+     * @param AttrValueInterface ...$values
+     * @return $this
+     */
     public function addValues(AttrValueInterface ...$values): self
     {
         $this->values = array_merge($this->values, $values);
         return $this;
+    }
+
+    /**
+     * Clones current `Attr` instance, then adds value items to that cloned instance.
+     *
+     * @param AttrValueInterface ...$values
+     * @return $this
+     */
+    public function withValues(AttrValueInterface ...$values): self
+    {
+        $differences = array_udiff($values, $this->values, [$this, 'isDifferentValue']);
+        if (empty($differences)) {
+            return $this;
+        }
+        $target = clone $this;
+        $target->values = array_merge($target->values, $values);
+        return $target;
     }
 
     public function getName(): string
@@ -110,5 +133,10 @@ class Attr
         // + matchFirstValue: false --> return true (since no other match failed before)
         // + matchFirstValue: true --> return false (since no other match succeeded before)
         return !$matchFirstValue;
+    }
+
+    protected function isDifferentValue(AttrValueInterface $a, AttrValueInterface $b): int
+    {
+        return (int)($a !== $b);
     }
 }

--- a/tests/Behavior/AttrTest.php
+++ b/tests/Behavior/AttrTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under the terms
+ * of the MIT License (MIT). For the full copyright and license information,
+ * please read the LICENSE file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\HtmlSanitizer\Tests\Behavior;
+
+use PHPUnit\Framework\TestCase;
+use TYPO3\HtmlSanitizer\Behavior\Attr;
+use TYPO3\HtmlSanitizer\Behavior\DatasetAttrValue;
+
+class AttrTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function addValuesKeepsInstance(): void
+    {
+        $valueA = new DatasetAttrValue('a1', 'a2');
+        $valueB = new DatasetAttrValue('b1', 'b2');
+        $valueC = new DatasetAttrValue('c1', 'c2');
+        $attr = new Attr('test');
+        self::assertSame($attr, $attr->addValues($valueA, $valueB, $valueC));
+    }
+
+    /**
+     * @test
+     */
+    public function withValuesKeepsInstance(): void
+    {
+        $valueA = new DatasetAttrValue('a1', 'a2');
+        $valueB = new DatasetAttrValue('b1', 'b2');
+        $valueC = new DatasetAttrValue('c1', 'c2');
+        $attr = new Attr('test');
+        $attr = $attr->addValues($valueA, $valueB, $valueC);
+        self::assertSame($attr, $attr->withValues($valueA));
+        self::assertSame($attr, $attr->withValues($valueA, $valueB));
+        self::assertSame($attr, $attr->withValues($valueA, $valueB, $valueC));
+    }
+
+    /**
+     * @test
+     */
+    public function withValuesClonesInstance(): void
+    {
+        $valueA = new DatasetAttrValue('a1', 'a2');
+        $valueB = new DatasetAttrValue('b1', 'b2');
+        $valueC = new DatasetAttrValue('c1', 'c2');
+        $attr = new Attr('test');
+        $attr = $attr->addValues($valueA, $valueB, $valueC);
+
+        $valueD = new DatasetAttrValue('d1', 'd2');
+        $valueE = new DatasetAttrValue('e1', 'e2');
+        self::assertNotSame($attr, $attr->withValues($valueD));
+        self::assertNotSame($attr, $attr->withValues($valueD, $valueE));
+        self::assertNotSame($attr, $attr->withValues($valueA, $valueD));
+    }
+}

--- a/tests/CommonBuilderTest.php
+++ b/tests/CommonBuilderTest.php
@@ -103,6 +103,14 @@ class CommonBuilderTest extends TestCase
                 '<img src="/typo3.org/logo.svg" alt="logo" loading="lazy" width="100" height="100" sizes="33.3vw" name="logo" align="left" border="0">',
                 '<img src="/typo3.org/logo.svg" alt="logo" loading="lazy" width="100" height="100" sizes="33.3vw" name="logo" align="left" border="0">',
             ],
+            '#047' => [
+                '<img src="data:text/html,<script>alert(1)</script>">',
+                '',
+            ],
+            '#48' => [
+                '<img src="data:image/png,..."><img src="data:image/png;,..."><img src="data:image/png;base64,..."><img src="data:image/svg+xml;base64,...">',
+                '<img src="data:image/png,..."><img src="data:image/png;,..."><img src="data:image/png;base64,..."><img src="data:image/svg+xml;base64,...">',
+            ],
             '#050' => [
                 '<a href="https://typo3.org/" role="button">value</a>',
                 '<a href="https://typo3.org/" role="button">value</a>',


### PR DESCRIPTION
In general, this change allows using `<img src="data:image/...">`.

* adds `source.src` value restrictions
* removes `img.srcset` value restrictions
* allows `img.src` with `image` data URI
* allows `audio.src` with `audio` data URI
* allows `video.src` with `video` data URI
* allows `source.src` with `audio`, `image`, `video` data URI

Fixes: #45