### PR TITLE
[TASK] Allow RFC 2392 compliant URI schemes

### DIFF
--- a/src/Builder/CommonBuilder.php
+++ b/src/Builder/CommonBuilder.php
@@ -54,17 +54,21 @@ class CommonBuilder implements BuilderInterface
         $isMailtoUri = new Behavior\RegExpAttrValue('#^mailto:#');
         // + starting with `tel:`
         $isTelUri = new Behavior\RegExpAttrValue('#^tel:#');
+        // + starting with `cid:` (emails, see https://datatracker.ietf.org/doc/html/rfc2392)
+        $isContentId = new Behavior\RegExpAttrValue('#^cid:#');
+        // + starting with `mid:` (emails, see https://datatracker.ietf.org/doc/html/rfc2392)
+        $isMessageId = new Behavior\RegExpAttrValue('#^mid:#');
 
         $this->globalAttrs = $this->createGlobalAttrs();
         $this->srcAttr = (new Behavior\Attr('src', Behavior\Attr::MATCH_FIRST_VALUE))
             // @todo consider adding `data:` check
-            ->addValues($isHttpOrLocalUri);
+            ->addValues($isHttpOrLocalUri, $isContentId);
         $this->srcsetAttr = (new Behavior\Attr('srcset', Behavior\Attr::MATCH_FIRST_VALUE))
             // @todo consider adding `data:` check
             // @todo Add test for `srcset="media.png 1080w"`
             ->addValues($isHttpOrLocalUri);
         $this->hrefAttr = (new Behavior\Attr('href', Behavior\Attr::MATCH_FIRST_VALUE))
-            ->addValues($isHttpOrLocalUri, $isMailtoUri, $isTelUri);
+            ->addValues($isHttpOrLocalUri, $isMailtoUri, $isTelUri, $isMessageId);
     }
 
     public function build(): Sanitizer

--- a/tests/CommonBuilderTest.php
+++ b/tests/CommonBuilderTest.php
@@ -203,6 +203,14 @@ class CommonBuilderTest extends TestCase
                 '<font class="font" color="#000000" face="Verdana,Arial" size="13">value</font>',
                 '<font class="font" color="#000000" face="Verdana,Arial" size="13">value</font>'
             ],
+            '#904' => [
+                '<img src="cid:DC117C9322DEB502C3B16769A8A64E08@example.test">',
+                '<img src="cid:DC117C9322DEB502C3B16769A8A64E08@example.test">',
+            ],
+            '#905' => [
+                '<a href="mid:D89CD33E-F9CF-4CA0-BCE3-AC89E5D41DE1@example.test/DC117C9322DEB502C3B16769A8A64E08@example.test">see previous message</a>',
+                '<a href="mid:D89CD33E-F9CF-4CA0-BCE3-AC89E5D41DE1@example.test/DC117C9322DEB502C3B16769A8A64E08@example.test">see previous message</a>',
+            ],
         ];
     }
 


### PR DESCRIPTION
Adds `cid:` and `mid:` email URI schemes.
see https://datatracker.ietf.org/doc/html/rfc2392

Fixes: #53