### PR TITLE
[TASK] Let test suite fail with E_ALL

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,4 +10,7 @@
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
+    <php>
+        <ini name="error_reporting" value="E_ALL" />
+    </php>
 </phpunit>


### PR DESCRIPTION
error_reporting default is E_ALL & ~E_DEPRECATED & ~E_STRICT.
In general, we should strive for E_ALL error free tests:
This helps to find issues with younger PHP versions more
quickly.