### PR TITLE
[FEATURE] Introduce mandatory tag attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ $behavior = (new Behavior())
         (new Behavior\Tag('div', Behavior\Tag::ALLOW_CHILDREN))
             ->addAttrs(...$commonAttrs),
         (new Behavior\Tag('a', Behavior\Tag::ALLOW_CHILDREN))
-            ->addAttrs($hrefAttr, ...$commonAttrs),
+            ->addAttrs(...$commonAttrs)
+            ->addAttrs($hrefAttr->withFlags(Behavior\Attr::MANDATORY)),
         (new Behavior\Tag('br'))
     );
 
@@ -66,6 +67,7 @@ $sanitizer = new Sanitizer(...$visitors);
 
 $html = <<< EOH
 <div id="main">
+    <a class="no-href">invalidated, due to missing mandatory `href` attr</a>
     <a href="https://typo3.org/" data-type="url" wrong-attr="is-removed">TYPO3</a><br>
     (the <span>SPAN, SPAN, SPAN</span> tag shall be encoded to HTML entities)
 </div>
@@ -78,6 +80,7 @@ will result in the following sanitized output
 
 ```html
 <div id="main">
+    &lt;a class="no-href"&gt;invalidated, due to missing mandatory `href` attr&lt;/a&gt;
     <a href="https://typo3.org/" data-type="url">TYPO3</a><br>
     (the &lt;span&gt;SPAN, SPAN, SPAN&lt;/span&gt; tag shall be encoded to HTML entities)
 </div>

--- a/src/Behavior/Attr.php
+++ b/src/Behavior/Attr.php
@@ -74,6 +74,16 @@ class Attr
         $this->flags = $flags;
     }
 
+    public function withFlags(int $flags): self
+    {
+        if ($flags === $this->flags) {
+            return $this;
+        }
+        $target = clone $this;
+        $target->flags = $flags;
+        return $target;
+    }
+
     /**
      * Adds value items directly to the current `Attr` instance.
      *
@@ -106,6 +116,11 @@ class Attr
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function getFlags(): int
+    {
+        return $this->flags;
     }
 
     /**

--- a/src/Behavior/Attr.php
+++ b/src/Behavior/Attr.php
@@ -47,6 +47,11 @@ class Attr
     public const MATCH_ALL_VALUES = 4;
 
     /**
+     * whether the current attribute is mandatory for the tag
+     */
+    public const MANDATORY = 8;
+
+    /**
      * either specific attribute name (`class`) or a prefix
      * (`data-`) in case corresponding NAME_PREFIX flag is set
      * @var string
@@ -127,6 +132,11 @@ class Attr
     public function shallMatchAllValues(): bool
     {
         return ($this->flags & self::MATCH_ALL_VALUES) === self::MATCH_ALL_VALUES;
+    }
+
+    public function isMandatory(): bool
+    {
+        return ($this->flags & self::MANDATORY) === self::MANDATORY;
     }
 
     public function matchesName(string $givenName): bool

--- a/src/Behavior/MultiTokenAttrValue.php
+++ b/src/Behavior/MultiTokenAttrValue.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under the terms
+ * of the MIT License (MIT). For the full copyright and license information,
+ * please read the LICENSE file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\HtmlSanitizer\Behavior;
+
+use LogicException;
+
+class MultiTokenAttrValue implements AttrValueInterface
+{
+    /**
+     * @var string
+     */
+    protected $delimiter;
+
+    /**
+     * @var list<string>
+     */
+    protected $tokens;
+
+    public function __construct(string $delimiter, string ...$tokens)
+    {
+        if ($delimiter === '') {
+            throw new LogicException('Delimiter cannot be empty', 1642111976);
+        }
+        $tokens = array_filter($tokens, [$this, 'keepNonEmpty']);
+        if ($tokens === []) {
+            throw new LogicException('Tokens cannot be empty or only empty strings', 1642111637);
+        }
+        $this->delimiter = $delimiter;
+        $this->tokens = $tokens;
+    }
+
+    public function matches(string $value): bool
+    {
+        $tokens = explode($this->delimiter, $value);
+        $tokens = array_filter($tokens, [$this, 'keepNonEmpty']);
+        // in case there is no token, the result implicit is `true`
+        // @todo has to be changed, in case mandatory tokes would be implemented
+        if (empty($tokens)) {
+            return true;
+        }
+        return array_diff($tokens, $this->tokens) === [];
+    }
+
+    protected function keepNonEmpty(string $item): bool
+    {
+        return $item !== '';
+    }
+}

--- a/tests/Behavior/AttrTest.php
+++ b/tests/Behavior/AttrTest.php
@@ -24,6 +24,18 @@ class AttrTest extends TestCase
     /**
      * @test
      */
+    public function withFlagsClonesInstance(): void
+    {
+        $attr = new Attr('test', Attr::BLUNT);
+        $modifiedAttr = $attr->withFlags(Attr::MANDATORY);
+        self::assertNotSame($attr, $modifiedAttr);
+        self::assertEquals(Attr::BLUNT, $attr->getFlags());
+        self::assertEquals(Attr::MANDATORY, $modifiedAttr->getFlags());
+    }
+
+    /**
+     * @test
+     */
     public function addValuesKeepsInstance(): void
     {
         $valueA = new DatasetAttrValue('a1', 'a2');
@@ -36,7 +48,7 @@ class AttrTest extends TestCase
     /**
      * @test
      */
-    public function withValuesKeepsInstance(): void
+    public function withValuesKeepsInstanceWhenNotModified(): void
     {
         $valueA = new DatasetAttrValue('a1', 'a2');
         $valueB = new DatasetAttrValue('b1', 'b2');
@@ -51,7 +63,7 @@ class AttrTest extends TestCase
     /**
      * @test
      */
-    public function withValuesClonesInstance(): void
+    public function withValuesClonesInstanceWhenModified(): void
     {
         $valueA = new DatasetAttrValue('a1', 'a2');
         $valueB = new DatasetAttrValue('b1', 'b2');

--- a/tests/ScenarioTest.php
+++ b/tests/ScenarioTest.php
@@ -115,9 +115,9 @@ class ScenarioTest extends TestCase
             '2:<script type="application/javascript">alert(2)</script>',
             // `type` attr will be removed -> no attrs -> tag will be removed due to `PURGE_WITHOUT_ATTRS`
             '3:<script type="application/ecmascript">alert(3)</script>',
-            // @todo not sanitized by `PURGE_WITHOUT_ATTRS` -> `type` attr value needs to be mandatory
+            // tag will be encoded due to incompleteness, mandatory `type` attr is missing
             '4:<script id="identifier">alert(1)</script>',
-            // @todo not sanitized by `PURGE_WITHOUT_ATTRS` -> `type` attr value needs to be mandatory
+            // tag will be encoded due to incompleteness, mandatory `type` attr mismatches
             '5:<script id="identifier" type="application/javascript">alert(2)</script>',
             // tag will be removed due to `PURGE_WITHOUT_CHILDREN`
             '6:<script type="application/ld+json"></script>',

--- a/tests/ScenarioTest.php
+++ b/tests/ScenarioTest.php
@@ -128,8 +128,8 @@ class ScenarioTest extends TestCase
             '1:',
             '2:',
             '3:',
-            '4:<script id="identifier">alert(1)</script>',
-            '5:<script id="identifier">alert(2)</script>',
+            '4:&lt;script id="identifier"&gt;alert(1)&lt;/script&gt;',
+            '5:&lt;script id="identifier"&gt;alert(2)&lt;/script&gt;',
             '6:',
             '7:<script type="application/ld+json">alert(4)</script>',
             '8:<script type="application/ld+json">{"@id": "https://github.com/TYPO3/html-sanitizer"}</script>',
@@ -144,7 +144,7 @@ class ScenarioTest extends TestCase
                     Behavior\Tag::PURGE_WITHOUT_ATTRS + Behavior\Tag::PURGE_WITHOUT_CHILDREN + Behavior\Tag::ALLOW_CHILDREN
                 ))->addAttrs(
                     (new Behavior\Attr('id')),
-                    (new Behavior\Attr('type'))
+                    (new Behavior\Attr('type', Behavior\Attr::MANDATORY))
                         ->addValues(new Behavior\DatasetAttrValue('application/ld+json'))
                 )
             );


### PR DESCRIPTION
Introduces new `Behavior\Attr::MANDATORY` flag, declaring an attribute must be given for a particular tag to be valid.

```:javascript
(new Behavior\Tag('script'))
  ->addAttrs(
    (new Behavior\Attr('type', Behavior\Attr::MANDATORY))
      ->addValues(new Behavior\DatasetAttrValue('application/ld+json'))
)
```

The example above allows `<script type="application/ld+json">...</script>` but disallows all other occurrences not having `type="application/ld+json"`, thus `<script>` or `<script type="application/javascript">` still would be invalid.

Related: #70, #71