### PR TITLE
Allow installation of any PSR-Log version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"ext-dom": "*",
 		"masterminds/html5": "^2.7",
 		"php": "^7.2 || ^8.0",
-		"psr/log": "^1.0"
+		"psr/log": "^1.0|^2.0|^3.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^8.5"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"ext-dom": "*",
 		"masterminds/html5": "^2.7",
 		"php": "^7.2 || ^8.0",
-		"psr/log": "^1.0|^2.0|^3.0"
+		"psr/log": "^1.0 || ^2.0 || ^3.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^8.5"


### PR DESCRIPTION
This package is, I think, the only one used by core that requires PSR-Log 1.0 specifically.  PSR-Log now has a 2.x and 3.x version that add type support.  The only reference to them is using the LoggerAware interface and trait, which are unchanged (API-wise, anyway), so this package is compatible with any PSR-Log version.

This would unblock bumping core up to PSR-Log 2.0 or ideally 3.0.