### PR TITLE
[TASK] Avoid phpunit cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /composer.lock
 /.idea
-/.phpunit.result.cache
 /vendor

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,6 +2,7 @@
 <phpunit
     bootstrap="vendor/autoload.php"
     backupGlobals="true"
+    cacheResult="false"
     colors="true"
     processIsolation="false"
     verbose="true">


### PR DESCRIPTION
A setting in phpunit.xml avoids creating the
.phpunit.result.cache file, which is pretty much
useless for this small repository anyways.