### PR TITLE
[TASK] Allow CI for any branch, add schedule, add badge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ main, v1 ]
   pull_request:
-    branches: [ main, v1 ]
+  schedule:
+    - cron:  '45 6 * * *'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![tests](https://github.com/TYPO3/html-sanitizer/actions/workflows/tests.yml/badge.svg)
+
 # TYPO3 HTML Sanitizer
 
 > :information_source: Common safe HTML tags & attributes as given in


### PR DESCRIPTION
Allowing github workflow runs for any branch is useful
for devs that develop things in a branch in their fork.
Also add a daily scheduled main branch run, plus a
badge to README.md.