### PR TITLE
[TASK] Add PHP 8.2 to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.4', '8.0', '8.1']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
     steps:
       - uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
           php-version: ${{ matrix.php }}
           tools: composer:v2
 
-      - name: Validate composer.json and composer.lock
+      - name: Validate composer.json
         run: composer validate
 
       - name: Lint PHP
@@ -32,7 +32,13 @@ jobs:
           find src/ tests/ -name '*.php' -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null
 
       - name: Install dependencies
+        if: ${{ matrix.php <= '8.1' }}
         run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Install dependencies PHP 8.2
+        # @todo: Needed until prophecy (req by phpunit) allows PHP 8.2, https://github.com/phpspec/prophecy/issues/556
+        if: ${{ matrix.php > '8.1' }}
+        run: composer install --prefer-dist --no-progress --no-suggest --ignore-platform-req=php+
 
       - name: Run test suite
         run: composer run-script test


### PR DESCRIPTION
This needs the quirk --ignore-platform-req=php+ in
tests.yml since prophecy as a direct phpunit
dependency does not allow PHP 8.2 yet, even though
html-sanitizer does not use prophecy.

See https://github.com/phpspec/prophecy/issues/556