### PR TITLE
[FEATURE] Add possibility to control comments and CDATA sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ $hrefAttr = (new Behavior\Attr('href'))
 // attention: only `Behavior` implementation uses immutability
 // (invoking `withFlags()` or `withTags()` returns new instance)
 $behavior = (new Behavior())
-    ->withFlags(Behavior::ENCODE_INVALID_TAG)
+    ->withFlags(Behavior::ENCODE_INVALID_TAG | Behavior::ENCODE_INVALID_COMMENT)
+    ->withoutNodes(new Behavior\Comment())
+    ->withNodes(new Behavior\CdataSection())
     ->withTags(
         (new Behavior\Tag('div', Behavior\Tag::ALLOW_CHILDREN))
             ->addAttrs(...$commonAttrs),
@@ -80,16 +82,25 @@ will result in the following sanitized output
 
 ```html
 <div id="main">
+    &lt;!-- will be encoded, due to Behavior::ENCODE_INVALID_COMMENT --&gt;
     &lt;a class="no-href"&gt;invalidated, due to missing mandatory `href` attr&lt;/a&gt;
     <a href="https://typo3.org/" data-type="url">TYPO3</a><br>
     (the &lt;span&gt;SPAN, SPAN, SPAN&lt;/span&gt; tag shall be encoded to HTML entities)
 </div>
 ```
 
+### Changes
+
+* since `v2.1.0` newly introduced nodes `Behavior\Comment` and  `Behavior\CdataSection` are enabled per
+  default for backward compatibility reasons, use e.g. `$behavior->withoutNodes(new Behavior\Comment())`
+  to remove them (later versions of this package won't have this fallback anymore)
+
 ### `Behavior` flags
 
 * `Behavior::ENCODE_INVALID_TAG` keeps invalid tags, but "disarms" them (see `<span>` in example)
 * `Behavior::ENCODE_INVALID_ATTR` keeps invalid attributes, but "disarms" the whole(!) tag
+* `Behavior::ENCODE_INVALID_COMMENT` "disarms" unexpected HTML comments by completely encoding them
+* `Behavior::ENCODE_INVALID_CDATA_SECTION` "disarms" unexpected HTML CDATA sections by completely encoding them
 * `Behavior::REMOVE_UNEXPECTED_CHILDREN` removes children for `Tag` entities that were created
   without explicitly using `Tag::ALLOW_CHILDREN`, but actually contained child nodes
 * `Behavior::ALLOW_CUSTOM_ELEMENTS` allow using custom elements (having a hyphen `-`) - however,

--- a/src/Behavior/CdataSection.php
+++ b/src/Behavior/CdataSection.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under the terms
+ * of the MIT License (MIT). For the full copyright and license information,
+ * please read the LICENSE file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\HtmlSanitizer\Behavior;
+
+/**
+ * Model of CDATA node.
+ */
+class CdataSection implements NodeInterface
+{
+    public function getName(): string
+    {
+        return '#cdata-section';
+    }
+}

--- a/src/Behavior/Comment.php
+++ b/src/Behavior/Comment.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under the terms
+ * of the MIT License (MIT). For the full copyright and license information,
+ * please read the LICENSE file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\HtmlSanitizer\Behavior;
+
+/**
+ * Model of comment node.
+ */
+class Comment implements NodeInterface
+{
+    public function getName(): string
+    {
+        return '#comment';
+    }
+}

--- a/src/Behavior/NodeInterface.php
+++ b/src/Behavior/NodeInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under the terms
+ * of the MIT License (MIT). For the full copyright and license information,
+ * please read the LICENSE file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\HtmlSanitizer\Behavior;
+
+/**
+ * Model of generic node (tag, comment, cdata, text, ...)
+ */
+interface NodeInterface
+{
+    public function getName(): string;
+}

--- a/src/Behavior/Tag.php
+++ b/src/Behavior/Tag.php
@@ -19,7 +19,7 @@ use LogicException;
 /**
  * Model of tag
  */
-class Tag
+class Tag implements NodeInterface
 {
     /**
      * not having any behavioral capabilities

--- a/tests/CommonBuilderTest.php
+++ b/tests/CommonBuilderTest.php
@@ -251,6 +251,18 @@ class CommonBuilderTest extends TestCase
                 '<a href="xmpp:user@example.org?message">value</a>',
                 '<a href="xmpp:user@example.org?message">value</a>',
             ],
+            '#909' => [
+                '<!-- #comment -->',
+                '<!-- #comment -->',
+            ],
+            '#910' => [
+                '<![CDATA[ #cdata ]]>',
+                '<![CDATA[ #cdata ]]>',
+            ],
+            '#911' => [
+                '#text',
+                '#text',
+            ],
         ];
     }
 


### PR DESCRIPTION
Comments and CDATA sections were implicitly allowed in earlier versions. This change allows to control these nodes better.

For backward compatibility reasons both new nodes `Behavior\Comment` and `Behavior\CdataSection` are enabled per default (which will be changed in a later version of this package). To disable comments and CDATA sections, they need to be removed using `withoutNode()`.

Example (disallows using `Comment` and `CdataSection`):

```php
use TYPO3\HtmlSanitizer\Behavior;

$behavior = (new Behavior())
    ->withFlags(Behavior::ENCODE_INVALID_COMMENT | Behavior::ENCODE_INVALID_CDATA_SECTION)
    ->withName('scenario-test')
    ->withTags(new Behavior\Tag('div', Behavior\Tag::ALLOW_CHILDREN))
    ->withoutNodes(new Behavior\Comment(), new Behavior\CdataSection());
```

Related: #89