### PR TITLE
[FEATURE] Add possibility to declare and apply presets to behavior

### DIFF
--- a/src/Behavior.php
+++ b/src/Behavior.php
@@ -16,6 +16,7 @@ namespace TYPO3\HtmlSanitizer;
 
 use LogicException;
 use TYPO3\HtmlSanitizer\Behavior\Tag;
+use TYPO3\HtmlSanitizer\Builder\Preset\PresetInterface;
 
 /**
  * Declares behavior used by node visitors
@@ -64,6 +65,11 @@ class Behavior
      * @var array<string, Tag>
      */
     protected $tags = [];
+
+    public function withPreset(PresetInterface $preset, int $flags = 0): self
+    {
+        return $preset->applyTo($this, $flags);
+    }
 
     public function withFlags(int $flags): self
     {

--- a/src/Builder/Preset/IframePreset.php
+++ b/src/Builder/Preset/IframePreset.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under the terms
+ * of the MIT License (MIT). For the full copyright and license information,
+ * please read the LICENSE file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\HtmlSanitizer\Builder\Preset;
+
+use TYPO3\HtmlSanitizer\Behavior;
+
+/**
+ * Preset for `<iframe>` element.
+ */
+class IframePreset implements PresetInterface
+{
+    public function applyTo(Behavior $behavior, int $flags = 0): Behavior
+    {
+        return $behavior->withTags(
+            (new Behavior\Tag('iframe'))->addAttrs(
+                (new Behavior\Attr('id')),
+                // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-allow
+                (new Behavior\Attr('allow'))->withValues(
+                    new Behavior\MultiTokenAttrValue(' ', 'fullscreen')
+                ),
+                // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
+                (new Behavior\Attr('sandbox', Behavior\Attr::MANDATORY))->withValues(
+                    new Behavior\EmptyAttrValue(),
+                    new Behavior\MultiTokenAttrValue(
+                        ' ',
+                        'allow-downloads',
+                        'allow-modals',
+                        'allow-orientation-lock',
+                        'allow-pointer-lock',
+                        'allow-popups',
+                        'allow-scripts'
+                    )
+                ),
+                (new Behavior\Attr('src'))->withValues(
+                    ...(new Behavior\Attr\UriAttrValueBuilder())
+                        ->allowSchemes('http', 'https')->getValues()
+                )
+            )
+        );
+    }
+}

--- a/src/Builder/Preset/PresetInterface.php
+++ b/src/Builder/Preset/PresetInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under the terms
+ * of the MIT License (MIT). For the full copyright and license information,
+ * please read the LICENSE file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\HtmlSanitizer\Builder\Preset;
+
+use TYPO3\HtmlSanitizer\Behavior;
+
+/**
+ * Interface for applying a preset declaration to an existing behavior.
+ */
+interface PresetInterface
+{
+    /**
+     * @param Behavior $behavior to be modified
+     * @param int $flags (currently not used, future topics such as `override`)
+     * @return Behavior having the preset applied
+     */
+    public function applyTo(Behavior $behavior, int $flags): Behavior;
+}

--- a/tests/ScenarioTest.php
+++ b/tests/ScenarioTest.php
@@ -16,7 +16,7 @@ namespace TYPO3\HtmlSanitizer\Tests;
 
 use PHPUnit\Framework\TestCase;
 use TYPO3\HtmlSanitizer\Behavior;
-use TYPO3\HtmlSanitizer\Behavior\Attr\UriAttrValueBuilder;
+use TYPO3\HtmlSanitizer\Builder\Preset\IframePreset;
 use TYPO3\HtmlSanitizer\Sanitizer;
 use TYPO3\HtmlSanitizer\Visitor\CommonVisitor;
 
@@ -185,32 +185,7 @@ class ScenarioTest extends TestCase
         $behavior = (new Behavior())
             ->withFlags(Behavior::ENCODE_INVALID_TAG | Behavior::REMOVE_UNEXPECTED_CHILDREN)
             ->withName('scenario-test')
-            ->withTags(
-                (new Behavior\Tag('iframe'))->addAttrs(
-                    (new Behavior\Attr('id')),
-                    // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-allow
-                    (new Behavior\Attr('allow'))->withValues(
-                        new Behavior\MultiTokenAttrValue(' ', 'fullscreen')
-                    ),
-                    // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
-                    (new Behavior\Attr('sandbox', Behavior\Attr::MANDATORY))->withValues(
-                        new Behavior\EmptyAttrValue(),
-                        new Behavior\MultiTokenAttrValue(
-                            ' ',
-                            'allow-downloads',
-                            'allow-modals',
-                            'allow-orientation-lock',
-                            'allow-pointer-lock',
-                            'allow-popups',
-                            'allow-scripts'
-                        )
-                    ),
-                    (new Behavior\Attr('src'))->withValues(
-                        ...(new UriAttrValueBuilder())->allowSchemes('http', 'https')->getValues()
-                    )
-                )
-            );
-
+            ->withPreset(new IframePreset());
         $sanitizer = new Sanitizer(
             new CommonVisitor($behavior)
         );


### PR DESCRIPTION
Example (uses preset declaring `<iframe>` and applies it):

```php
use TYPO3\HtmlSanitizer\Behavior;
use TYPO3\HtmlSanitizer\Builder\Preset\IframePreset;

$behavior = (new Behavior())
    ->withFlags(Behavior::ENCODE_INVALID_TAG | Behavior::REMOVE_UNEXPECTED_CHILDREN)
    ->withName('scenario-test')
    ->withPreset(new IframePreset());
```

Related: #91