### PR TITLE
[FEATURE] Add posibility to handle nodes individually

### DIFF
--- a/src/Behavior/Handler/AsTextHandler.php
+++ b/src/Behavior/Handler/AsTextHandler.php
@@ -16,7 +16,6 @@ namespace TYPO3\HtmlSanitizer\Behavior\Handler;
 
 use DOMNode;
 use DOMText;
-use LogicException;
 use TYPO3\HtmlSanitizer\Behavior;
 use TYPO3\HtmlSanitizer\Behavior\HandlerInterface;
 use TYPO3\HtmlSanitizer\Behavior\NodeInterface;
@@ -29,12 +28,6 @@ class AsTextHandler implements HandlerInterface
         if ($domNode === null) {
             return null;
         }
-        // @todo might use `DOMChildNode` with PHP 8
-        if (($domNode->parentNode ?? null) === null) {
-            throw new LogicException('Cannot process nodes not having a parent', 1666333132);
-        }
-        $text = new DOMText();
-        $text->nodeValue = $context->parser->saveHTML($domNode);
-        return $text;
+        return new DOMText($context->parser->saveHTML($domNode));
     }
 }

--- a/src/Behavior/Handler/AsTextHandler.php
+++ b/src/Behavior/Handler/AsTextHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under the terms
+ * of the MIT License (MIT). For the full copyright and license information,
+ * please read the LICENSE file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\HtmlSanitizer\Behavior\Handler;
+
+use DOMNode;
+use DOMText;
+use LogicException;
+use TYPO3\HtmlSanitizer\Behavior;
+use TYPO3\HtmlSanitizer\Behavior\HandlerInterface;
+use TYPO3\HtmlSanitizer\Behavior\NodeInterface;
+use TYPO3\HtmlSanitizer\Context;
+
+class AsTextHandler implements HandlerInterface
+{
+    public function handle(NodeInterface $node, ?DOMNode $domNode, Context $context, Behavior $behavior = null): ?DOMNode
+    {
+        if ($domNode === null) {
+            return null;
+        }
+        // @todo might use `DOMChildNode` with PHP 8
+        if (($domNode->parentNode ?? null) === null) {
+            throw new LogicException('Cannot process nodes not having a parent', 1666333132);
+        }
+        $text = new DOMText();
+        $text->nodeValue = $context->parser->saveHTML($domNode);
+        return $text;
+    }
+}

--- a/src/Behavior/Handler/ClosureHandler.php
+++ b/src/Behavior/Handler/ClosureHandler.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under the terms
+ * of the MIT License (MIT). For the full copyright and license information,
+ * please read the LICENSE file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\HtmlSanitizer\Behavior\Handler;
+
+use Closure;
+use DOMNode;
+use LogicException;
+use TYPO3\HtmlSanitizer\Behavior;
+use TYPO3\HtmlSanitizer\Behavior\HandlerInterface;
+use TYPO3\HtmlSanitizer\Behavior\NodeInterface;
+use TYPO3\HtmlSanitizer\Context;
+
+class ClosureHandler implements HandlerInterface
+{
+    /**
+     * @var Closure
+     */
+    protected $closure;
+
+    public function __construct(Closure $closure)
+    {
+        $this->closure = $closure;
+    }
+
+    public function handle(NodeInterface $node, ?DOMNode $domNode, Context $context, Behavior $behavior = null): ?DOMNode
+    {
+        $result = call_user_func($this->closure, $node, $domNode, $context, $behavior);
+        if ($result !== null && !$result instanceof DOMNode) {
+            throw new LogicException('Closure must return either null or DOMNode', 1666342014);
+        }
+        return $result;
+    }
+}

--- a/src/Behavior/HandlerInterface.php
+++ b/src/Behavior/HandlerInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under the terms
+ * of the MIT License (MIT). For the full copyright and license information,
+ * please read the LICENSE file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\HtmlSanitizer\Behavior;
+
+use DOMNode;
+use TYPO3\HtmlSanitizer\Behavior;
+use TYPO3\HtmlSanitizer\Context;
+
+interface HandlerInterface
+{
+    public function handle(NodeInterface $node, ?DOMNode $domNode, Context $context, Behavior $behavior = null): ?DOMNode;
+}

--- a/src/Behavior/NodeHandler.php
+++ b/src/Behavior/NodeHandler.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under the terms
+ * of the MIT License (MIT). For the full copyright and license information,
+ * please read the LICENSE file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\HtmlSanitizer\Behavior;
+
+class NodeHandler implements NodeInterface
+{
+    /**
+     * Whether defaults shall be processed (e.g. verifying all attributes etc.)
+     */
+    public const PROCESS_DEFAULTS = 1;
+
+    /**
+     * Whether this handler shall be processed first (before processing defaults)
+     */
+    public const HANDLE_FIRST = 2;
+
+    /**
+     * @var NodeInterface
+     */
+    protected $node;
+
+    /**
+     * @var HandlerInterface
+     */
+    protected $handler;
+
+    /**
+     * @var int
+     */
+    protected $flags;
+
+    public function __construct(NodeInterface $node, HandlerInterface $handler, int $flags = 0)
+    {
+        $this->node = $node;
+        $this->handler = $handler;
+        $this->flags = $flags;
+    }
+
+    public function getName(): string
+    {
+        return $this->node->getName();
+    }
+
+    public function getNode(): NodeInterface
+    {
+        return $this->node;
+    }
+
+    public function getHandler(): HandlerInterface
+    {
+        return $this->handler;
+    }
+
+    public function getFlags(): int
+    {
+        return $this->flags;
+    }
+
+    public function shallProcessDefaults(): bool
+    {
+        return ($this->flags & self::PROCESS_DEFAULTS) === self::PROCESS_DEFAULTS;
+    }
+
+    public function shallHandleFirst(): bool
+    {
+        return ($this->flags & self::HANDLE_FIRST) === self::HANDLE_FIRST;
+    }
+}


### PR DESCRIPTION
The new `NodeHandler(NodeInterface $node, HandlerInterface $handler)` allows to handle DOM nodes individually. The optional flags `PROCESS_DEFAULTS` and `HANDLE_FIRST` can be used to invoke the default processing in addition to the custom handler.

Related: #77