### PR TITLE
[TASK] Streamline `\TYPO3\HtmlSanitizer\Sanitizer` 

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,3 +6,4 @@
   use `\TYPO3\HtmlSanitizer\Behavior\NodeException::withDomNode(?DOMNode $domNode)` instead
 * deprecated `\TYPO3\HtmlSanitizer\Behavior\NodeException::getNode()`,
   use `\TYPO3\HtmlSanitizer\Behavior\NodeException::getDomNode()` instead
+* deprecated property `\TYPO3\HtmlSanitizer\Sanitizer::$root`, superfluous - don't use it anymore

--- a/src/Context.php
+++ b/src/Context.php
@@ -28,7 +28,7 @@ class Context
     public $parser;
 
     /**
-     * @var InitiatorInterface
+     * @var ?InitiatorInterface
      */
     public $initiator;
 

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -73,16 +73,22 @@ class Sanitizer
     public function sanitize(string $html, InitiatorInterface $initiator = null): string
     {
         $this->root = $this->parse($html);
-        $this->context = new Context($this->parser, $initiator);
-        $this->beforeTraverse();
-        $this->traverseNodeList($this->root->childNodes);
-        $this->afterTraverse();
+        $this->handle($this->root, $initiator);
         return $this->serialize($this->root);
     }
 
     protected function parse(string $html): DOMDocumentFragment
     {
         return $this->parser->parseFragment($html);
+    }
+
+    protected function handle(DOMNode $domNode, InitiatorInterface $initiator = null): DOMNode
+    {
+        $this->context = new Context($this->parser, $initiator);
+        $this->beforeTraverse();
+        $this->traverseNodeList($domNode->childNodes);
+        $this->afterTraverse();
+        return $domNode;
     }
 
     protected function serialize(DOMNode $document): string

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -56,6 +56,7 @@ class Sanitizer
 
     /**
      * @var DOMDocumentFragment
+     * @deprecated since v2.1.0, not required anymore
      */
     protected $root;
 
@@ -72,9 +73,11 @@ class Sanitizer
 
     public function sanitize(string $html, InitiatorInterface $initiator = null): string
     {
-        $this->root = $this->parse($html);
-        $this->handle($this->root, $initiator);
-        return $this->serialize($this->root);
+        $root = $this->parse($html);
+        // @todo drop deprecated property
+        $this->root = $root;
+        $this->handle($root, $initiator);
+        return $this->serialize($root);
     }
 
     protected function parse(string $html): DOMDocumentFragment

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -36,6 +36,14 @@ use TYPO3\HtmlSanitizer\Visitor\VisitorInterface;
  */
 class Sanitizer
 {
+    protected const mastermindsDefaultOptions = [
+        // Whether the serializer should aggressively encode all characters as entities.
+        'encode_entities' => false,
+        // Prevents the parser from automatically assigning the HTML5 namespace to the DOM document.
+        // (adjusted due to https://github.com/Masterminds/html5-php/issues/181#issuecomment-643767471)
+        'disable_html_ns' => true,
+    ];
+
     /**
      * @var VisitorInterface[]
      */
@@ -149,10 +157,6 @@ class Sanitizer
 
     protected function createParser(): HTML5
     {
-        // set parser & applies work-around
-        // https://github.com/Masterminds/html5-php/issues/181#issuecomment-643767471
-        return new HTML5([
-            'disable_html_ns' => true,
-        ]);
+        return new HTML5(self::mastermindsDefaultOptions);
     }
 }


### PR DESCRIPTION
* Adjust PHPdoc comment
* Declare all default options for Masterminds parser
* Organize node handling in dedicated method
* Deprecate superfluous property Sanitizer::$root
