### PR TITLE
[!!!][FEATURE] Allow to use custom output rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $behavior = (new Behavior())
     );
 
 $visitors = [new CommonVisitor($behavior)];
-$sanitizer = new Sanitizer(...$visitors);
+$sanitizer = new Sanitizer($behavior, ...$visitors);
 
 $html = <<< EOH
 <div id="main">

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,3 +7,6 @@
 * deprecated `\TYPO3\HtmlSanitizer\Behavior\NodeException::getNode()`,
   use `\TYPO3\HtmlSanitizer\Behavior\NodeException::getDomNode()` instead
 * deprecated property `\TYPO3\HtmlSanitizer\Sanitizer::$root`, superfluous - don't use it anymore
+* requirement to provide instance of `\TYPO3\HtmlSanitizer\Behavior` when creating a
+  new instance of `\TYPO3\HtmlSanitizer\Sanitizer` (for backward compatibility, this
+  is not a hard requirement yet), adjust to use `new Sanitizer($behavior, ...$visitors)`

--- a/src/Builder/CommonBuilder.php
+++ b/src/Builder/CommonBuilder.php
@@ -70,7 +70,7 @@ class CommonBuilder implements BuilderInterface
     {
         $behavior = $this->createBehavior();
         $visitor = new CommonVisitor($behavior);
-        return new Sanitizer($visitor);
+        return new Sanitizer($behavior, $visitor);
     }
 
     protected function createBehavior(): Behavior

--- a/src/Serializer/Rules.php
+++ b/src/Serializer/Rules.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under the terms
+ * of the MIT License (MIT). For the full copyright and license information,
+ * please read the LICENSE file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\HtmlSanitizer\Serializer;
+
+use DOMNode;
+use Masterminds\HTML5\Serializer\OutputRules;
+use Masterminds\HTML5\Serializer\Traverser;
+use TYPO3\HtmlSanitizer\Behavior;
+
+class Rules extends OutputRules implements RulesInterface
+{
+    /**
+     * @var array
+     */
+    protected $options;
+
+    /**
+     * @var ?Traverser
+     */
+    protected $traverser;
+
+    /**
+     * @var ?Behavior
+     */
+    protected $behavior;
+
+    /**
+     * @param Behavior $behavior
+     * @param resource$output
+     * @param array $options
+     * @return self
+     */
+    public static function create(Behavior $behavior, $output, array $options = []): self
+    {
+        $target = new self($output, $options);
+        $target->options = $options;
+        $target->behavior = $behavior;
+        return $target;
+    }
+
+    public function traverse(DOMNode $domNode): void
+    {
+        $traverser = new Traverser($domNode, $this->out, $this, $this->options);
+        $traverser->walk();
+        // release the traverser to avoid cyclic references and allow PHP
+        // to free memory without waiting for gc_collect_cycles
+        $this->unsetTraverser();
+    }
+
+    /**
+     * @return resource
+     */
+    public function getStream()
+    {
+        return $this->out;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+}

--- a/src/Serializer/RulesInterface.php
+++ b/src/Serializer/RulesInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under the terms
+ * of the MIT License (MIT). For the full copyright and license information,
+ * please read the LICENSE file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\HtmlSanitizer\Serializer;
+
+use DOMNode;
+use Masterminds\HTML5\Serializer\RulesInterface as MastermindsRulesInterface;
+
+interface RulesInterface extends MastermindsRulesInterface
+{
+    public function traverse(DOMNode $domNode): void;
+
+    /**
+     * @return resource
+     */
+    public function getStream();
+
+    public function getOptions(): array;
+}

--- a/tests/ScenarioTest.php
+++ b/tests/ScenarioTest.php
@@ -42,6 +42,7 @@ class ScenarioTest extends TestCase
     {
         $behavior = new Behavior();
         $sanitizer = new Sanitizer(
+            $behavior,
             new CommonVisitor($behavior)
         );
         self::assertSame($expectation, $sanitizer->sanitize($payload));
@@ -101,6 +102,7 @@ class ScenarioTest extends TestCase
             );
 
         $sanitizer = new Sanitizer(
+            $behavior,
             new CommonVisitor($behavior)
         );
         self::assertSame($expectation, $sanitizer->sanitize($payload));
@@ -186,6 +188,7 @@ class ScenarioTest extends TestCase
             ->withName('scenario-test')
             ->withNodes($nodeHandler);
         $sanitizer = new Sanitizer(
+            $behavior,
             new CommonVisitor($behavior)
         );
         self::assertSame($expectation, $sanitizer->sanitize($payload));
@@ -234,6 +237,7 @@ class ScenarioTest extends TestCase
         $comment = new Behavior\Comment();
         $behavior = $allowed ? $behavior->withNodes($comment) : $behavior->withoutNodes($comment);
         $sanitizer = new Sanitizer(
+            $behavior,
             new CommonVisitor($behavior)
         );
         self::assertSame($expectation, $sanitizer->sanitize($payload));
@@ -282,6 +286,7 @@ class ScenarioTest extends TestCase
         $cdataSection = new Behavior\CdataSection();
         $behavior = $allowed ? $behavior->withNodes($cdataSection) : $behavior->withoutNodes($cdataSection);
         $sanitizer = new Sanitizer(
+            $behavior,
             new CommonVisitor($behavior)
         );
         self::assertSame($expectation, $sanitizer->sanitize($payload));
@@ -338,6 +343,7 @@ class ScenarioTest extends TestCase
             );
 
         $sanitizer = new Sanitizer(
+            $behavior,
             new CommonVisitor($behavior)
         );
         self::assertSame($expectation, $sanitizer->sanitize($payload));
@@ -396,6 +402,7 @@ class ScenarioTest extends TestCase
             );
 
         $sanitizer = new Sanitizer(
+            $behavior,
             new CommonVisitor($behavior)
         );
         self::assertSame($expectation, $sanitizer->sanitize($payload));


### PR DESCRIPTION
As a consequence, it is required to have `Behavior` available in `Sanitizer`. As fall back and for the time being, this is not a hard requirement - but it will change in future versions of this library.