### PR TITLE
[BUGFIX] Declare `CommonVisitor::$logger`

### DIFF
--- a/src/Visitor/CommonVisitor.php
+++ b/src/Visitor/CommonVisitor.php
@@ -33,6 +33,11 @@ use TYPO3\HtmlSanitizer\Context;
 class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
 {
     use LoggerAwareTrait;
+    
+    /**
+     * @var NullLogger
+     */
+    protected $logger;
 
     /**
      * @var Behavior


### PR DESCRIPTION
The class property `CommonVisitor::$logger` is now properly declared.