### PR TITLE
[TASK] Backport library to support PHP 7.0 and 7.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ This `typo3/html-sanitizer` package aims to be a standalone component that can b
 project or library. Albeit it is released within the TYPO3 namespace, it is agnostic to specifics of
 [TYPO3 CMS](https://github.com/typo3/typo3).
 
+> :warning: Version 1.5 of `typo3/html-sanitizer` is a transitional version
+> between v1 and v2 to support PHP 7.0 and PHP 7.1.
+
 + [`\TYPO3\HtmlSanitizer\Behavior`](src/Behavior.php) contains declarative settings for
   a particular process for sanitizing HTML.
 + [`\TYPO3\HtmlSanitizer\Visitor\VisitorInterface`](src/Visitor/VisitorInterface.php)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,9 +1,9 @@
 # TYPO3 HTML Sanitizer notices for upgrading
 
-## v2.1.0
+## v1.5.0
 
-* deprecated `\TYPO3\HtmlSanitizer\Behavior\NodeException::withNode(?DOMNode $node)`,
-  use `\TYPO3\HtmlSanitizer\Behavior\NodeException::withDomNode(?DOMNode $domNode)` instead
+* deprecated `\TYPO3\HtmlSanitizer\Behavior\NodeException::withNode($node)`,
+  use `\TYPO3\HtmlSanitizer\Behavior\NodeException::withDomNode($domNode)` instead
 * deprecated `\TYPO3\HtmlSanitizer\Behavior\NodeException::getNode()`,
   use `\TYPO3\HtmlSanitizer\Behavior\NodeException::getDomNode()` instead
 * deprecated property `\TYPO3\HtmlSanitizer\Sanitizer::$root`, superfluous - don't use it anymore

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
 	"require": {
 		"ext-dom": "*",
 		"masterminds/html5": "^2.7.6",
-		"php": "^7.2 || ^8.0",
+		"php": "^7.0 || ^8.0",
 		"psr/log": "^1.0 || ^2.0 || ^3.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^8.5"
+		"phpunit/phpunit": "^6.5 || ^8.5"
 	},
 	"scripts": {
 		"test": "phpunit"

--- a/src/Behavior.php
+++ b/src/Behavior.php
@@ -27,38 +27,38 @@ class Behavior
     /**
      * not having any behavioral capabilities
      */
-    public const BLUNT = 0;
+    const BLUNT = 0;
 
     /**
      * in case an unexpected tag was found, encode the whole tag as HTML
      */
-    public const ENCODE_INVALID_TAG = 1;
+    const ENCODE_INVALID_TAG = 1;
 
     /**
      * in case an unexpected attribute was found, encode the whole tag as HTML
      */
-    public const ENCODE_INVALID_ATTR = 2;
+    const ENCODE_INVALID_ATTR = 2;
 
     /**
      * remove children at nodes that did not expect children
      */
-    public const REMOVE_UNEXPECTED_CHILDREN = 4;
+    const REMOVE_UNEXPECTED_CHILDREN = 4;
 
     /**
      * https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name
      * custom elements must contain a hyphen (`-`), start with ASCII lower alpha
      */
-    public const ALLOW_CUSTOM_ELEMENTS = 8;
+    const ALLOW_CUSTOM_ELEMENTS = 8;
 
     /**
      * in case an unexpected comment was found, encode the whole comment as HTML
      */
-    public const ENCODE_INVALID_COMMENT = 16;
+    const ENCODE_INVALID_COMMENT = 16;
 
     /**
      * in case an unexpected CDATA section was found, encode the whole CDATA section as HTML
      */
-    public const ENCODE_INVALID_CDATA_SECTION = 32;
+    const ENCODE_INVALID_CDATA_SECTION = 32;
 
     /**
      * @var int
@@ -136,7 +136,7 @@ class Behavior
         $names = array_map([$this, 'getNodeName'], $nodes);
         $filteredNodes = array_filter(
             $this->nodes,
-            static function (?NodeInterface $node, string $name) use ($nodes, $names) {
+            static function ($node, string $name) use ($nodes, $names) {
                 return $node === null && !in_array($name, $names, true)
                     || $node !== null && !in_array($node, $nodes, true);
             },
@@ -173,7 +173,10 @@ class Behavior
         );
     }
 
-    public function getTag(string $name): ?Tag
+    /**
+     * @return Tag|null
+     */
+    public function getTag(string $name)
     {
         $name = strtolower($name);
         $node = $this->nodes[$name] ?? null;
@@ -188,7 +191,10 @@ class Behavior
         return $this->nodes;
     }
 
-    public function getNode(string $name): ?NodeInterface
+    /**
+     * @return NodeInterface|null
+     */
+    public function getNode(string $name)
     {
         $name = strtolower($name);
         return $this->nodes[$name] ?? null;
@@ -231,9 +237,10 @@ class Behavior
 
     /**
      * @param list<string> $names
+     * @return void
      * @throws LogicException
      */
-    protected function assertScalarUniqueness(array $names): void
+    protected function assertScalarUniqueness(array $names)
     {
         $ambiguousNames = array_diff_assoc($names, array_unique($names));
         if ($ambiguousNames !== []) {
@@ -249,8 +256,9 @@ class Behavior
 
     /**
      * @param array<string, NodeInterface> $nodes
+     * @return void
      */
-    protected function assertNodeUniqueness(array $nodes): void
+    protected function assertNodeUniqueness(array $nodes)
     {
         $existingNodeNames = array_intersect_key(array_filter($this->nodes), $nodes);
         if ($existingNodeNames !== []) {

--- a/src/Behavior/Attr.php
+++ b/src/Behavior/Attr.php
@@ -22,13 +22,13 @@ class Attr
     /**
      * not having any behavioral capabilities
      */
-    public const BLUNT = 0;
+    const BLUNT = 0;
 
     /**
      * whether given name shall be considered as prefix, e.g.
      * `data-` or `aria-` for multiple similar and safe attribute names
      */
-    public const NAME_PREFIX = 1;
+    const NAME_PREFIX = 1;
 
     /**
      * whether the first match in `$values` shall be considered
@@ -37,19 +37,19 @@ class Attr
      *
      * @deprecated since version 2.0.13 (it is the default behavior now)
      */
-    public const MATCH_FIRST_VALUE = 2;
+    const MATCH_FIRST_VALUE = 2;
 
     /**
      * whether all `$values` shall be considered as indicator an
      * attribute value is valid - if this flag is not given, the
      * first match in `$values` is taken
      */
-    public const MATCH_ALL_VALUES = 4;
+    const MATCH_ALL_VALUES = 4;
 
     /**
      * whether the current attribute is mandatory for the tag
      */
-    public const MANDATORY = 8;
+    const MANDATORY = 8;
 
     /**
      * either specific attribute name (`class`) or a prefix

--- a/src/Behavior/Handler/AsTextHandler.php
+++ b/src/Behavior/Handler/AsTextHandler.php
@@ -23,7 +23,14 @@ use TYPO3\HtmlSanitizer\Context;
 
 class AsTextHandler implements HandlerInterface
 {
-    public function handle(NodeInterface $node, ?DOMNode $domNode, Context $context, Behavior $behavior = null): ?DOMNode
+    /**
+     * @param NodeInterface $node
+     * @param DOMNode|null $domNode
+     * @param Context $context
+     * @param Behavior|null $behavior
+     * @return DOMNode|null
+     */
+    public function handle(NodeInterface $node, $domNode, Context $context, Behavior $behavior = null)
     {
         if ($domNode === null) {
             return null;

--- a/src/Behavior/Handler/ClosureHandler.php
+++ b/src/Behavior/Handler/ClosureHandler.php
@@ -34,7 +34,14 @@ class ClosureHandler implements HandlerInterface
         $this->closure = $closure;
     }
 
-    public function handle(NodeInterface $node, ?DOMNode $domNode, Context $context, Behavior $behavior = null): ?DOMNode
+    /**
+     * @param NodeInterface $node
+     * @param DOMNode|null $domNode
+     * @param Context $context
+     * @param Behavior|null $behavior
+     * @return DOMNode|null
+     */
+    public function handle(NodeInterface $node, $domNode, Context $context, Behavior $behavior = null)
     {
         $result = call_user_func($this->closure, $node, $domNode, $context, $behavior);
         if ($result !== null && !$result instanceof DOMNode) {

--- a/src/Behavior/HandlerInterface.php
+++ b/src/Behavior/HandlerInterface.php
@@ -20,5 +20,12 @@ use TYPO3\HtmlSanitizer\Context;
 
 interface HandlerInterface
 {
-    public function handle(NodeInterface $node, ?DOMNode $domNode, Context $context, Behavior $behavior = null): ?DOMNode;
+    /**
+     * @param NodeInterface $node
+     * @param DOMNode|null $domNode
+     * @param Context $context
+     * @param Behavior|null $behavior
+     * @return DOMNode|null
+     */
+    public function handle(NodeInterface $node, $domNode, Context $context, Behavior $behavior = null);
 }

--- a/src/Behavior/NodeException.php
+++ b/src/Behavior/NodeException.php
@@ -29,30 +29,38 @@ class NodeException extends RuntimeException
      */
     protected $domNode;
 
-    public function withDomNode(?DOMNode $domNode): self
+    /**
+     * @param DOMNode|null $domNode
+     */
+    public function withDomNode($domNode): self
     {
         $this->domNode = $domNode;
         return $this;
     }
 
     /**
-     * @deprecated since v2.1.0, use withDomNode(?DOMNode $domNode) instead
+     * @param DOMNode|null $domNode
+     * @deprecated since v1.5.0, use withDomNode(?DOMNode $domNode) instead
      */
-    public function withNode(?DOMNode $domNode): self
+    public function withNode($domNode): self
     {
         $this->domNode = $domNode;
         return $this;
     }
 
-    public function getDomNode(): ?DOMNode
+    /**
+     * @return DOMNode|null
+     */
+    public function getDomNode()
     {
         return $this->domNode;
     }
 
     /**
-     * @deprecated since v2.1.0, use getDomNode() instead
+     * @return DOMNode|null
+     * @deprecated since v1.5.0, use getDomNode() instead
      */
-    public function getNode(): ?DOMNode
+    public function getNode()
     {
         return $this->domNode;
     }

--- a/src/Behavior/NodeHandler.php
+++ b/src/Behavior/NodeHandler.php
@@ -19,12 +19,12 @@ class NodeHandler implements NodeInterface
     /**
      * Whether defaults shall be processed (e.g. verifying all attributes etc.)
      */
-    public const PROCESS_DEFAULTS = 1;
+    const PROCESS_DEFAULTS = 1;
 
     /**
      * Whether this handler shall be processed first (before processing defaults)
      */
-    public const HANDLE_FIRST = 2;
+    const HANDLE_FIRST = 2;
 
     /**
      * @var NodeInterface

--- a/src/Behavior/Tag.php
+++ b/src/Behavior/Tag.php
@@ -24,22 +24,22 @@ class Tag implements NodeInterface
     /**
      * not having any behavioral capabilities
      */
-    public const BLUNT = 0;
+    const BLUNT = 0;
 
     /**
      * whether to purge this tag in case it does not have any attributes
      */
-    public const PURGE_WITHOUT_ATTRS = 1;
+    const PURGE_WITHOUT_ATTRS = 1;
 
     /**
      * whether to purge this tag in case it does not have children
      */
-    public const PURGE_WITHOUT_CHILDREN = 2;
+    const PURGE_WITHOUT_CHILDREN = 2;
 
     /**
      * whether this tag allows to have children
      */
-    public const ALLOW_CHILDREN = 8;
+    const ALLOW_CHILDREN = 8;
 
     /**
      * @var string
@@ -112,7 +112,10 @@ class Tag implements NodeInterface
         return ($this->flags & self::ALLOW_CHILDREN) === self::ALLOW_CHILDREN;
     }
 
-    public function getAttr(string $name): ?Attr
+    /**
+     * @return Attr|null
+     */
+    public function getAttr(string $name)
     {
         $name = strtolower($name);
         if (isset($this->attrs[$name])) {
@@ -128,9 +131,10 @@ class Tag implements NodeInterface
 
     /**
      * @param string[] $names
+     * @return void
      * @throws LogicException
      */
-    protected function assertScalarUniqueness(array $names): void
+    protected function assertScalarUniqueness(array $names)
     {
         $ambiguousNames = array_diff_assoc($names, array_unique($names));
         if ($ambiguousNames !== []) {
@@ -146,9 +150,10 @@ class Tag implements NodeInterface
 
     /**
      * @param array<string, Attr> $attrs
+     * @return void
      * @throws LogicException
      */
-    protected function assertAttrUniqueness(array $attrs): void
+    protected function assertAttrUniqueness(array $attrs)
     {
         $existingAttrNames = [];
         $currentAttrNames = array_keys($this->attrs);

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -38,7 +38,10 @@ use TYPO3\HtmlSanitizer\Visitor\VisitorInterface;
  */
 class Sanitizer
 {
-    protected const mastermindsDefaultOptions = [
+    /**
+     * @internal
+     */
+    const mastermindsDefaultOptions = [
         // Whether the serializer should aggressively encode all characters as entities.
         'encode_entities' => false,
         // Prevents the parser from automatically assigning the HTML5 namespace to the DOM document.
@@ -63,7 +66,7 @@ class Sanitizer
 
     /**
      * @var DOMDocumentFragment
-     * @deprecated since v2.1.0, not required anymore
+     * @deprecated since v1.5.0, not required anymore
      */
     protected $root;
 
@@ -126,14 +129,20 @@ class Sanitizer
         return stream_get_contents($rules->getStream(), -1, 0);
     }
 
-    protected function beforeTraverse(): void
+    /**
+     * @return void
+     */
+    protected function beforeTraverse()
     {
         foreach ($this->visitors as $visitor) {
             $visitor->beforeTraverse($this->context);
         }
     }
 
-    protected function traverse(DOMNode $domNode): void
+    /**
+     * @return void
+     */
+    protected function traverse(DOMNode $domNode)
     {
         foreach ($this->visitors as $visitor) {
             $result = $visitor->enterNode($domNode);
@@ -161,8 +170,9 @@ class Sanitizer
      * directly removing child nodes, keeping node-list indexes.
      *
      * @param DOMNodeList $domNodeList
+     * @return void
      */
-    protected function traverseNodeList(DOMNodeList $domNodeList): void
+    protected function traverseNodeList(DOMNodeList $domNodeList)
     {
         for ($i = $domNodeList->length - 1; $i >= 0; $i--) {
             /** @var DOMNode $item */
@@ -171,14 +181,21 @@ class Sanitizer
         }
     }
 
-    protected function afterTraverse(): void
+    /**
+     * @return void
+     */
+    protected function afterTraverse()
     {
         foreach ($this->visitors as $visitor) {
             $visitor->afterTraverse($this->context);
         }
     }
 
-    protected function replaceNode(DOMNode $source, ?DOMNode $target): ?DOMNode
+    /**
+     * @param DOMNode|null $target
+     * @return DOMNode|null
+     */
+    protected function replaceNode(DOMNode $source, $target)
     {
         if ($target === null) {
             $source->parentNode->removeChild($source);

--- a/src/Serializer/Rules.php
+++ b/src/Serializer/Rules.php
@@ -76,7 +76,10 @@ class Rules extends OutputRules implements RulesInterface
         return $target;
     }
 
-    public function withInitiator(?InitiatorInterface $initiator): self
+    /**
+     * @param InitiatorInterface|null $initiator
+     */
+    public function withInitiator($initiator): self
     {
         if ($this->initiator === $initiator) {
             return $this;
@@ -86,7 +89,10 @@ class Rules extends OutputRules implements RulesInterface
         return $target;
     }
 
-    public function traverse(DOMNode $domNode): void
+    /**
+     * @return void
+     */
+    public function traverse(DOMNode $domNode)
     {
         $traverser = new Traverser($domNode, $this->out, $this, $this->options);
         $traverser->walk();

--- a/src/Serializer/RulesInterface.php
+++ b/src/Serializer/RulesInterface.php
@@ -27,11 +27,15 @@ interface RulesInterface extends MastermindsRulesInterface
     public function withBehavior(Behavior $behavior);
 
     /**
+     * @param InitiatorInterface|null $initiator
      * @return self
      */
-    public function withInitiator(?InitiatorInterface $initiator);
+    public function withInitiator($initiator);
 
-    public function traverse(DOMNode $domNode): void;
+    /**
+     * @return void
+     */
+    public function traverse(DOMNode $domNode);
 
     /**
      * @return resource

--- a/src/Visitor/AbstractVisitor.php
+++ b/src/Visitor/AbstractVisitor.php
@@ -22,21 +22,33 @@ use TYPO3\HtmlSanitizer\Context;
  */
 abstract class AbstractVisitor implements VisitorInterface
 {
-    public function beforeTraverse(Context $context): void
+    /**
+     * @return void
+     */
+    public function beforeTraverse(Context $context)
     {
     }
 
-    public function enterNode(DOMNode $domNode): ?DOMNode
+    /**
+     * @return DOMNode|null
+     */
+    public function enterNode(DOMNode $domNode)
     {
         return $domNode;
     }
 
-    public function leaveNode(DOMNode $domNode): ?DOMNode
+    /**
+     * @return DOMNode|null
+     */
+    public function leaveNode(DOMNode $domNode)
     {
         return $domNode;
     }
 
-    public function afterTraverse(Context $context): void
+    /**
+     * @return void
+     */
+    public function afterTraverse(Context $context)
     {
     }
 }

--- a/src/Visitor/CommonVisitor.php
+++ b/src/Visitor/CommonVisitor.php
@@ -50,7 +50,10 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
         $this->behavior = $behavior;
     }
 
-    public function beforeTraverse(Context $context): void
+    /**
+     * @return void
+     */
+    public function beforeTraverse(Context $context)
     {
         $this->context = $context;
         // v2.1.0: adding `#comment` and `#cdata-section` nodes for backward compatibility, will be removed with v3.0.0
@@ -62,7 +65,10 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
         }
     }
 
-    public function enterNode(DOMNode $domNode): ?DOMNode
+    /**
+     * @return DOMNode|null
+     */
+    public function enterNode(DOMNode $domNode)
     {
         if (!$domNode instanceof DOMCdataSection
             && !$domNode instanceof DOMComment
@@ -92,7 +98,11 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
         return $domNode;
     }
 
-    protected function enterDomElement(?DOMNode $domNode, Behavior\NodeInterface $node): ?DOMNode
+    /**
+     * @param DOMNode|null $domNode
+     * @return DOMNode|null
+     */
+    protected function enterDomElement($domNode, Behavior\NodeInterface $node)
     {
         if (!$domNode instanceof DOMElement || !$node instanceof Behavior\Tag) {
             return $domNode;
@@ -106,7 +116,10 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
         return $this->handleMandatoryAttributes($domNode, $node);
     }
 
-    public function leaveNode(DOMNode $domNode): ?DOMNode
+    /**
+     * @return DOMNode|null
+     */
+    public function leaveNode(DOMNode $domNode)
     {
         if (!$domNode instanceof DOMElement) {
             return $domNode;
@@ -127,7 +140,11 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
         return $domNode;
     }
 
-    protected function processAttributes(?DOMNode $domNode, Behavior\Tag $tag): ?DOMNode
+    /**
+     * @param DOMNode|null $domNode
+     * @return DOMNode|null
+     */
+    protected function processAttributes($domNode, Behavior\Tag $tag)
     {
         if (!$domNode instanceof DOMElement) {
             return $domNode;
@@ -146,7 +163,11 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
         return $domNode;
     }
 
-    protected function processChildren(?DOMNode $domNode, Behavior\Tag $tag): ?DOMNode
+    /**
+     * @param DOMNode|null $domNode
+     * @return DOMNode|null
+     */
+    protected function processChildren($domNode, Behavior\Tag $tag)
     {
         if (!$domNode instanceof DOMElement) {
             return $domNode;
@@ -171,9 +192,10 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
     }
 
     /**
+     * @return void
      * @throws Behavior\NodeException
      */
-    protected function processAttribute(DOMElement $domNode, Behavior\Tag $tag, DOMAttr $attribute): void
+    protected function processAttribute(DOMElement $domNode, Behavior\Tag $tag, DOMAttr $attribute)
     {
         $name = strtolower($attribute->name);
         $attr = $tag->getAttr($name);
@@ -187,7 +209,11 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
         }
     }
 
-    protected function handleMandatoryAttributes(?DOMNode $domNode, Behavior\Tag $tag): ?DOMNode
+    /**
+     * @param DOMNode|null $domNode
+     * @return DOMNode|null
+     */
+    protected function handleMandatoryAttributes($domNode, Behavior\Tag $tag)
     {
         if (!$domNode instanceof DOMElement) {
             return $domNode;
@@ -205,7 +231,10 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
         return $domNode;
     }
 
-    protected function handleInvalidNode(DOMNode $domNode): ?DOMNode
+    /**
+     * @return DOMNode|null
+     */
+    protected function handleInvalidNode(DOMNode $domNode)
     {
         if ($domNode instanceof DOMComment && $this->behavior->shallEncodeInvalidComment()) {
             return $this->convertToText($domNode);
@@ -234,9 +263,10 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
     }
 
     /**
+     * @return void
      * @throws Behavior\NodeException
      */
-    protected function handleInvalidAttr(DOMNode $domNode, string $name): void
+    protected function handleInvalidAttr(DOMNode $domNode, string $name)
     {
         if ($this->behavior->shallEncodeInvalidAttr()) {
             throw Behavior\NodeException::create()->withDomNode($this->convertToText($domNode));
@@ -291,7 +321,10 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
             && preg_match('#^[a-z][a-z0-9]*-.+#', $domNode->nodeName) > 0;
     }
 
-    protected function log(string $message, array $context = [], $level = null): void
+    /**
+     * @return void
+     */
+    protected function log(string $message, array $context = [], $level = null)
     {
         // @todo consider given minimum log-level
         if (!isset($context['initiator'])) {

--- a/src/Visitor/VisitorInterface.php
+++ b/src/Visitor/VisitorInterface.php
@@ -39,7 +39,7 @@ interface VisitorInterface
      * @param DOMNode $domNode
      * @return DOMNode|null
      */
-    public function enterNode(DOMNode $domNode): ?DOMNode;
+    public function enterNode(DOMNode $domNode);
 
     /**
      * Executed when leaving a node level.
@@ -50,7 +50,7 @@ interface VisitorInterface
      * @param DOMNode $domNode
      * @return DOMNode|null
      */
-    public function leaveNode(DOMNode $domNode): ?DOMNode;
+    public function leaveNode(DOMNode $domNode);
 
     /**
      * Executed after having traversed all nodes

--- a/tests/Behavior/AttrTest.php
+++ b/tests/Behavior/AttrTest.php
@@ -24,7 +24,7 @@ class AttrTest extends TestCase
     /**
      * @test
      */
-    public function withFlagsClonesInstance(): void
+    public function withFlagsClonesInstance()
     {
         $attr = new Attr('test', Attr::BLUNT);
         $modifiedAttr = $attr->withFlags(Attr::MANDATORY);
@@ -36,7 +36,7 @@ class AttrTest extends TestCase
     /**
      * @test
      */
-    public function addValuesKeepsInstance(): void
+    public function addValuesKeepsInstance()
     {
         $valueA = new DatasetAttrValue('a1', 'a2');
         $valueB = new DatasetAttrValue('b1', 'b2');
@@ -48,7 +48,7 @@ class AttrTest extends TestCase
     /**
      * @test
      */
-    public function withValuesKeepsInstanceWhenNotModified(): void
+    public function withValuesKeepsInstanceWhenNotModified()
     {
         $valueA = new DatasetAttrValue('a1', 'a2');
         $valueB = new DatasetAttrValue('b1', 'b2');
@@ -63,7 +63,7 @@ class AttrTest extends TestCase
     /**
      * @test
      */
-    public function withValuesClonesInstanceWhenModified(): void
+    public function withValuesClonesInstanceWhenModified()
     {
         $valueA = new DatasetAttrValue('a1', 'a2');
         $valueB = new DatasetAttrValue('b1', 'b2');
@@ -99,7 +99,7 @@ class AttrTest extends TestCase
      * @test
      * @dataProvider matchesNameDataProvider
      */
-    public function matchesName(int $flags, string $name, string $matchName, bool $expectation): void
+    public function matchesName(int $flags, string $name, string $matchName, bool $expectation)
     {
         $attr = new Attr($name, $flags);
         self::assertSame($expectation, $attr->matchesName($matchName));
@@ -139,7 +139,7 @@ class AttrTest extends TestCase
      * @test
      * @dataProvider matchesValueDataProvider
      */
-    public function matchesValue(int $flags, array $values, string $matchValue, bool $expectation): void
+    public function matchesValue(int $flags, array $values, string $matchValue, bool $expectation)
     {
         $attr = new Attr('test', $flags);
         $attr->addValues(...$values);

--- a/tests/Behavior/TagTest.php
+++ b/tests/Behavior/TagTest.php
@@ -39,7 +39,7 @@ class TagTest extends TestCase
      * @test
      * @dataProvider ambiguityIsDetectedDataProvider
      */
-    public function ambiguityIsDetected(array $originalNames, array $additionalNames, int $code = 0): void
+    public function ambiguityIsDetected(array $originalNames, array $additionalNames, int $code = 0)
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionCode($code);

--- a/tests/BehaviorTest.php
+++ b/tests/BehaviorTest.php
@@ -39,7 +39,7 @@ class BehaviorTest extends TestCase
      * @test
      * @dataProvider ambiguityIsDetectedDataProvider
      */
-    public function ambiguityIsDetected(array $originalNames, array $additionalNames, int $code = 0): void
+    public function ambiguityIsDetected(array $originalNames, array $additionalNames, int $code = 0)
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionCode($code);

--- a/tests/CommonBuilderTest.php
+++ b/tests/CommonBuilderTest.php
@@ -272,7 +272,7 @@ class CommonBuilderTest extends TestCase
      * @test
      * @dataProvider isSanitizedDataProvider
      */
-    public function isSanitized(string $payload, string $expectation): void
+    public function isSanitized(string $payload, string $expectation)
     {
         $builder = new CommonBuilder();
         $sanitizer = $builder->build();

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -21,7 +21,7 @@ class EnvironmentTest extends TestCase
     /**
      * @test
      */
-    public function reportsAllErrors(): void
+    public function reportsAllErrors()
     {
         self::assertSame(E_ALL, error_reporting());
     }

--- a/tests/ScenarioTest.php
+++ b/tests/ScenarioTest.php
@@ -28,7 +28,7 @@ class ScenarioTest extends TestCase
     /**
      * @test
      */
-    public function missingBehaviorTriggersDeprecationError(): void
+    public function missingBehaviorTriggersDeprecationError()
     {
         $this->markTestSkipped('see https://github.com/TYPO3/html-sanitizer/issues/99');
 
@@ -54,7 +54,7 @@ class ScenarioTest extends TestCase
      * @test
      * @dataProvider allTagsAreRemovedOnMissingDeclarationDataProvider
      */
-    public function allTagsAreRemovedOnMissingDeclaration(string $payload, string $expectation): void
+    public function allTagsAreRemovedOnMissingDeclaration(string $payload, string $expectation)
     {
         $behavior = new Behavior();
         $sanitizer = new Sanitizer(
@@ -106,7 +106,7 @@ class ScenarioTest extends TestCase
      * @test
      * @dataProvider tagFlagsAreProcessedDataProvider
      */
-    public function tagFlagsAreProcessed(int $flags, string $payload, string $expectation): void
+    public function tagFlagsAreProcessed(int $flags, string $payload, string $expectation)
     {
         $behavior = (new Behavior())
             ->withFlags(Behavior::ENCODE_INVALID_TAG | Behavior::REMOVE_UNEXPECTED_CHILDREN)
@@ -129,7 +129,7 @@ class ScenarioTest extends TestCase
         $node = new Behavior\Tag('div');
         $asTextHandler = new Behavior\Handler\AsTextHandler();
         $closureHandler = new Behavior\Handler\ClosureHandler(
-            static function (NodeInterface $node, ?DOMNode $domNode): ?\DOMNode {
+            static function (NodeInterface $node, $domNode) {
                 if ($domNode === null) {
                     return null;
                 }
@@ -197,7 +197,7 @@ class ScenarioTest extends TestCase
      * @test
      * @dataProvider tagIsHandledDataProcessor
      */
-    public function tagIsHandled(Behavior\NodeHandler $nodeHandler, string $payload, string $expectation): void
+    public function tagIsHandled(Behavior\NodeHandler $nodeHandler, string $payload, string $expectation)
     {
         $behavior = (new Behavior())
             ->withFlags(Behavior::REMOVE_UNEXPECTED_CHILDREN)
@@ -244,7 +244,7 @@ class ScenarioTest extends TestCase
      * @test
      * @dataProvider commentsAreHandledDataProvider
      */
-    public function commentsAreHandled(bool $allowed, int $flags, string $payload, string $expectation): void
+    public function commentsAreHandled(bool $allowed, int $flags, string $payload, string $expectation)
     {
         $behavior = (new Behavior())
             ->withFlags($flags)
@@ -293,7 +293,7 @@ class ScenarioTest extends TestCase
      * @test
      * @dataProvider cdataSectionsAreHandledDataProvider
      */
-    public function cdataSectionsAreHandled(bool $allowed, int $flags, string $payload, string $expectation): void
+    public function cdataSectionsAreHandled(bool $allowed, int $flags, string $payload, string $expectation)
     {
         $behavior = (new Behavior())
             ->withFlags($flags)
@@ -311,7 +311,7 @@ class ScenarioTest extends TestCase
     /**
      * @test
      */
-    public function isJsonLdScriptAllowed(): void
+    public function isJsonLdScriptAllowed()
     {
         $payload = implode("\n" , [
             // tag will be removed due to `PURGE_WITHOUT_ATTRS`
@@ -368,7 +368,7 @@ class ScenarioTest extends TestCase
     /**
      * @test
      */
-    public function iframeSandboxIsAllowed(): void
+    public function iframeSandboxIsAllowed()
     {
         $payload = implode("\n" , [
             '1:<iframe src="https://example.org/"></iframe>',


### PR DESCRIPTION
The PHP code of this library is backported to additionally support both PHP 7.0 and PHP 7.1.

In order to achieve this, const visibility, nullable types and `void` types were removed and replaced with PHPDoc comments where applicable.