### PR TITLE
Sanitizer constructor documents array instead of spread

### DIFF
--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -73,7 +73,7 @@ class Sanitizer
     protected $context;
 
     /**
-     * @param Behavior|VisitorInterface[] $items
+     * @param Behavior|VisitorInterface ...$items
      *
      * @todo use `__construct(Behavior $behavior, VisitorInterface ...$visitors)`
      * (which would have been a breaking change with a PHP fatal error)


### PR DESCRIPTION
Fix errors surfaced by PHPStan...

 > Parameter #2 ...$items of class TYPO3\HtmlSanitizer\Sanitizer constructor expects array<TYPO3\HtmlSanitizer\Visitor\VisitorInterface>|TYPO3\HtmlSanitizer\Behavior, TYPO3\HtmlSanitizer\Visitor\CommonVisitor given.