### PR TITLE
[TASK] Streamline logging

### DIFF
--- a/src/Visitor/CommonVisitor.php
+++ b/src/Visitor/CommonVisitor.php
@@ -160,6 +160,7 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
         ) {
             $this->log('Found unexpected children for {nodeName}', [
                 'behavior' => $this->behavior->getName(),
+                'nodeType' => $domNode->nodeType,
                 'nodeName' => $domNode->nodeName,
             ]);
             // reverse processing of children,
@@ -183,6 +184,7 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
         if ($attr === null || !$attr->matchesValue($attribute->value)) {
             $this->log('Found invalid attribute {nodeName}.{attrName}', [
                 'behavior' => $this->behavior->getName(),
+                'nodeType' => $domNode->nodeType,
                 'nodeName' => $domNode->nodeName,
                 'attrName' => $attribute->nodeName,
             ]);
@@ -199,6 +201,7 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
             if ($attr->isMandatory() && !$domNode->hasAttribute($attr->getName())) {
                 $this->log('Missing mandatory attribute {nodeName}.{attrName}', [
                     'behavior' => $this->behavior->getName(),
+                    'nodeType' => $domNode->nodeType,
                     'nodeName' => $domNode->nodeName,
                     'attrName' => $attr->getName(),
                 ]);
@@ -210,10 +213,15 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
 
     protected function handleInvalidNode(DOMNode $domNode): ?DOMNode
     {
-        if ($domNode instanceof DOMComment && $this->behavior->shallEncodeInvalidComment()) {
-            return $this->convertToText($domNode);
-        }
-        if ($domNode instanceof DOMCdataSection && $this->behavior->shallEncodeInvalidCdataSection()) {
+        if (
+            ($domNode instanceof DOMComment && $this->behavior->shallEncodeInvalidComment())
+            || ($domNode instanceof DOMCdataSection && $this->behavior->shallEncodeInvalidCdataSection())
+        ) {
+            $this->log('Found unexpected node {nodeName}', [
+                'behavior' => $this->behavior->getName(),
+                'nodeType' => $domNode->nodeType,
+                'nodeName' => $domNode->nodeName,
+            ]);
             return $this->convertToText($domNode);
         }
         if ($domNode instanceof DOMElement) {
@@ -221,18 +229,25 @@ class CommonVisitor extends AbstractVisitor implements LoggerAwareInterface
             if ($this->behavior->shallAllowCustomElements() && $this->isCustomElement($domNode)) {
                 $this->log('Allowed custom element {nodeName}', [
                     'behavior' => $this->behavior->getName(),
+                    'nodeType' => $domNode->nodeType,
                     'nodeName' => $domNode->nodeName,
                 ]);
                 return $domNode;
             }
             $this->log('Found unexpected tag {nodeName}', [
                 'behavior' => $this->behavior->getName(),
+                'nodeType' => $domNode->nodeType,
                 'nodeName' => $domNode->nodeName,
             ]);
             if ($this->behavior->shallEncodeInvalidTag()) {
                 return $this->convertToText($domNode);
             }
         }
+        $this->log('Removed unexpected node {nodeName}', [
+            'behavior' => $this->behavior->getName(),
+            'nodeType' => $domNode->nodeType,
+            'nodeName' => $domNode->nodeName,
+        ]);
         return null;
     }
 


### PR DESCRIPTION
Added logging for encoding #comment and #cdata nodes, and for nodes that were completely removed. All log items were enriched with the `nodeType (int)` property [1].

[1] https://www.php.net/manual/en/dom.constants.php